### PR TITLE
Allow users to specify custom environment variable to override default API Key environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ steps:
         server: "${MY_OCTOPUS_SERVER}"
 ```
 
+## Configuring
+
+### `OCTOPUS_CLI_SERVER`
+
+Your Octopus Server URL should be set to this environment variable, or you can use `server` in the steps of your pipeline instead.
+
+### `OCTOPUS_CLI_API_KEY`
+
+Your Octopus Server API key should be set to this environment variable, either in your pipeline’s environment variable settings or exposed in an [environment hook](https://buildkite.com/docs/pipelines/secrets#storing-secrets-in-environment-hooks). If you need different keys for different steps in your pipeline use `api_key` instead.
+
 ## 📥 Inputs
 
 **The following inputs are required:**
@@ -136,7 +146,7 @@ steps:
 
 | Name                           | Description                                                                                                                                                                                                                                                          |  Default   |
 | :----------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------: |
-| `api_key`                      | The API key used to access Octopus Deploy. You must provide an API key or set the `OCTOPUS_CLI_API_KEY` environment variable. If the guest account is enabled, a key of `API-GUEST` may be used. It is strongly recommended that this value retrieved from an environment variable.
+| `api_key`                      | The environment variable that is configured with your Octopus Server API key used to access Octopus Deploy. Use this if you need to specify different keys for different steps in your pipeline.
 | `channel`                      | The name or ID of the channel to use for the new release. If omitted, the best channel will be selected.                                                                                                                                                             |            |
 | `config_file`                  | The path to a configuration file of default values with one `key=value` per line.                                                                                                                                                                                    |            |
 | `debug`                        | Enable debug logging.                                                                                                                                                                                                                                                |  `false`   |

--- a/hooks/command
+++ b/hooks/command
@@ -158,7 +158,7 @@ fi
 
 #api_key:
 if [[ -n "${BUILDKITE_PLUGIN_CREATE_RELEASE_API_KEY:-}" ]]; then
-    args+=( "--apiKey" "${BUILDKITE_PLUGIN_CREATE_RELEASE_API_KEY}" )
+    args+=( "--apiKey" "$(eval "echo \$${BUILDKITE_PLUGIN_CREATE_RELEASE_API_KEY}")" )
     maskedArgs+=( "--apiKey" "SECRET" )
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,7 +7,7 @@ configuration:
   properties:
     api_key:
       type: string
-      description: 'The API key used to access Octopus Deploy. You must provide an API key or set the OCTOPUS_CLI_API_KEY environment variable. If the guest account is enabled, a key of API-GUEST may be used. It is strongly recommended that this value retrieved from an environment variable.'
+      description: 'Specifies the environment variable containing the Octopus Server API key'
     channel:
       type: string
       description: 'The name or ID of the channel to use for the new release. If omitted, the best channel will be selected.'

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -123,3 +123,25 @@ load "$BATS_PATH/load.bash"
     unstub octo
     unset BUILDKITE_PLUGIN_CREATE_RELEASE_PROJECT
 }
+
+@test "Run create release overriding Server URL and API Key" {
+    export FAKE_API_KEY="API-123"
+    export BUILDKITE_PLUGIN_CREATE_RELEASE_API_KEY="FAKE_API_KEY"
+    export BUILDKITE_PLUGIN_CREATE_RELEASE_SERVER="https://octopus.example"
+    export BUILDKITE_PLUGIN_CREATE_RELEASE_PROJECT="Test project"
+    export BUILDKITE_PLUGIN_CREATE_RELEASE_RELEASE_NUMBER="1.0.0"
+
+    stub octo "create-release --project 'Test project' --releaseNumber 1.0.0 --server https://octopus.example --apiKey API-123 : echo octo command ran"
+
+    run $PWD/hooks/command
+
+    assert_output --partial "octo command ran"
+    assert_success
+
+    unstub octo
+
+    unset BUILDKITE_PLUGIN_CREATE_RELEASE_API_KEY
+    unset BUILDKITE_PLUGIN_CREATE_RELEASE_SERVER
+    unset BUILDKITE_PLUGIN_CREATE_RELEASE_PROJECT
+    unset BUILDKITE_PLUGIN_CREATE_RELEASE_RELEASE_NUMBER
+}


### PR DESCRIPTION
> Plugins directly interpolate the API key into the `pipeline.yml`, which means there’s a risk of it being logged and passed around.

This PR is to address the above feedback from Buildkite about how we allowed users to enter their API keys directly in the yaml for our plugin